### PR TITLE
Prepare 0.4.0 pub.dev metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,48 +1,83 @@
 # Changelog
 
+## 0.4.0
+
+- Switched the default README to English for pub.dev and GitHub discovery.
+- Moved the original Chinese README to `README_CHINESE.md`.
+- Updated package metadata with an English description focused on Flutter
+  candlestick charts, K-line charts, financial charts, technical indicators,
+  OHLCV trading charts, and depth charts.
+- Translated the changelog to English to improve pub.dev package scoring.
+
 ## 0.3.1
 
-- 更新文档
+- Updated package documentation.
 
 ## 0.3.0
 
-- 破坏性调整：移除默认指标 enum API，改为基于 `KLineIndicatorSpec<T>` 和 `KLineIndicatorSeries<T>` 的动态指标定义。
-- 新增 `KLineWidget.mainIndicators` / `secondaryIndicators`，指标选择器以传入列表为唯一来源；不传使用默认指标，传空列表表示不展示对应指标。
-- 将 `KLineDataAdapter.indicatorValue` 改为接收 `String valueId`，业务侧可以直接支持任意自定义指标值。
-- 新增 `KLineDefaultIndicators` class 常量和工厂，保留 MA、EMA、BOLL、VOL、MACD、KDJ、RSI、WR 默认指标能力。
-- 支持自定义副图指标：普通 series 指标自动绘制折线、计算范围和展示标签；复杂指标可通过 `KLineIndicatorSpec.renderer` 自定义绘制。
-- 优化默认占位高度和视口高度计算，统一通过 delegate 获取高度，避免默认副图和自定义 indicator 高度不一致。
-- 修复缩小后旧滚动偏移超过新内容宽度时右侧偶发空白/闪动的问题，并抽离 `ScaleGestureHandler` 管理缩放手势逻辑。
-- 更新 example 自定义指标页面，演示默认 VOL、CCI 折线指标和自定义柱状 renderer 混合使用。
+- Breaking change: replaced the default indicator enum API with dynamic
+  indicator definitions based on `KLineIndicatorSpec<T>` and
+  `KLineIndicatorSeries<T>`.
+- Added `KLineWidget.mainIndicators` and `secondaryIndicators`; the indicator
+  selector now uses the provided lists as the single source of truth. Omitted
+  lists use defaults, and empty lists hide the corresponding indicators.
+- Changed `KLineDataAdapter.indicatorValue` to accept `String valueId`, so apps
+  can support arbitrary custom indicator values.
+- Added `KLineDefaultIndicators` constants and factories for built-in MA, EMA,
+  BOLL, VOL, MACD, KDJ, RSI, and WR indicators.
+- Added custom sub-chart indicator support. Simple series indicators are drawn
+  automatically, while complex indicators can provide a custom renderer through
+  `KLineIndicatorSpec.renderer`.
+- Improved default placeholder height and viewport height calculation by using
+  delegate-provided heights consistently.
+- Fixed occasional blank space or flicker on the right side when old scroll
+  offsets exceeded the new content width after zooming out, and extracted
+  `ScaleGestureHandler` for scale gesture logic.
+- Updated the example custom indicator page to demonstrate default VOL, CCI
+  line indicators, and a custom bar renderer together.
 
 ## 0.2.0
 
-- 新增 `KLineController` 实时场景控制能力：支持跟随最新、滚动到最新、滚动到指定下标和 reveal 当前选中项。
-- 新增实时更新示例页，演示业务层先更新数据，再主动调用 controller 滚动到目标位置。
-- 优化 K 线滚动边界同步，修复滚动到底部附近偶发不触发加载更多，以及加载更多后视图偏移漂移的问题。
-- 修复 example K 线缓存窗口逻辑，避免刷新 50 条数据时被已加载更多的内存数据污染。
-- 调整实时更新 demo 的 timer 行为，只有开启“跟随最新数据”时才自动模拟推送。
-- 修复默认指标切换栏高度使用硬编码的问题，改为读取布局配置。
-- 补充实时数据接入文档，明确 package 不负责判断数据插入位置。
-- 更新发布忽略规则，避免 `build/` 构建产物进入 pub 包。
+- Added realtime controls to `KLineController`: follow latest, scroll to latest,
+  scroll to index, and reveal the selected item.
+- Added a realtime update example page showing how business code updates data
+  first and then calls the controller to scroll to the target position.
+- Improved K-line scroll boundary synchronization and fixed edge cases where
+  loading more data did not trigger near the end or caused viewport drift.
+- Fixed the example K-line cache window so refreshing 50 rows is not polluted by
+  previously loaded-more in-memory data.
+- Adjusted the realtime demo timer so simulated pushes only run when follow
+  latest is enabled.
+- Replaced the hard-coded default indicator switcher height with layout config.
+- Added realtime data integration docs clarifying that the package does not
+  decide where incoming data should be inserted.
+- Updated publish ignore rules so `build/` artifacts are not included in the pub
+  package.
 
 ## 0.1.2
 
-- 将项目 `.fvmrc` 调整为当前 FVM 兼容的 JSON 格式，修复 `fvm flutter` 和 `example` 下 `make gen` 无法执行的问题。
-- 同步 `example/pubspec.lock` 中的本地 path 依赖版本到 `0.1.1`。
+- Changed `.fvmrc` to the current FVM-compatible JSON format, fixing
+  `fvm flutter` and `make gen` under `example`.
+- Synced the local path dependency version in `example/pubspec.lock` to
+  `0.1.1`.
 
 ## 0.1.1
 
-- 更新 package 名称为 `kline_flutter`，同步公共入口和示例导入路径。
-- 完善发布配置，补充 `LICENSE`、`.pubignore` 和发布校验所需文件。
-- 优化 `README.md` 首屏展示、快速接入说明和核心优势文案。
-- 将 README 展示图片切换为 GitHub raw URL，避免图片资源进入 pub 发布包。
-- 缩小自定义 UI 图片在 README 中的展示尺寸，提升文档阅读体验。
+- Renamed the package to `kline_flutter` and updated the public entrypoint and
+  example imports.
+- Completed publish configuration with `LICENSE`, `.pubignore`, and required
+  publish validation files.
+- Improved the first README screen, quick-start instructions, and core value
+  proposition copy.
+- Switched README preview images to GitHub raw URLs to keep image assets out of
+  the pub package.
+- Reduced custom UI image display width in the README for better readability.
 
 ## 0.1.0
 
-- 初始发布 Flutter K 线图组件。
-- 支持 `KLineWidget` 快速接入和 `KLineChartDelegate` 深度自定义绘制。
-- 支持 MA、EMA、BOLL、MACD、KDJ、RSI、WR、VOL 等默认指标展示。
-- 新增深度图 `DeepChart`，支持买卖盘累计深度展示。
-- 提供 example、详细使用文档和自定义 UI 示例。
+- Initial release of the Flutter K-line chart component.
+- Added quick integration through `KLineWidget` and deep custom drawing through
+  `KLineChartDelegate`.
+- Added default MA, EMA, BOLL, MACD, KDJ, RSI, WR, and VOL indicators.
+- Added `DeepChart` for cumulative bid and ask depth charts.
+- Added examples, detailed usage docs, and custom UI samples.

--- a/README.md
+++ b/README.md
@@ -4,109 +4,126 @@
 [![Dart](https://img.shields.io/badge/Dart-3.7.0+-blue.svg)](https://dart.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-一个面向金融行情场景的 Flutter 图表库，提供 K 线图、技术指标、交互控制和深度图能力。它以 `CustomPainter` 和 delegate 架构为核心，让你既可以快速接入一套默认 UI，也可以在真实业务中按需替换绘制、布局、覆盖层和数据适配。
+A Flutter candlestick chart and financial chart library for K-line charts,
+technical indicators, trading chart interactions, OHLCV data, and cumulative
+depth charts. It uses `CustomPainter` and delegate-based rendering, so you can
+start with the default UI and replace drawing, layout, overlays, or data
+adapters only where your app needs custom behavior.
 
-详细使用方式、自定义 UI、深度图接入和 example 说明请参考 [`example/use_docs.md`](example/use_docs.md)。
+Chinese documentation is available in [`README_CHINESE.md`](README_CHINESE.md).
+For custom UI, depth chart integration, external controls, realtime data, and
+complete examples, see [`example/use_docs.md`](example/use_docs.md).
 
-## 效果预览
+## Preview
 
-### 动态指标与指标文案
+### Dynamic Indicators and Labels
 
 <img
   src="https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_custom_indicator_text.png"
-  alt="动态指标与指标文案演示"
+  alt="Dynamic indicator labels"
   width="360"
 />
 
-[查看动态指标绘制视频](https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_dynamic_indicator_draw.webm)
+[Watch the dynamic indicator demo](https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_dynamic_indicator_draw.webm)
 
-### 滚动与缩放
+### Scroll and Zoom
 
 <img
   src="https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_scrolling.gif"
-  alt="滚动与缩放演示"
+  alt="Scroll and zoom demo"
   width="360"
 />
 
-### 长按详情
+### Long-press Details
 
 <img
   src="https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_tap_longpress_dataDetail.gif"
-  alt="长按十字线演示"
+  alt="Long press crosshair demo"
   width="360"
 />
 
-### 自定义背景
+### Custom Background
 
 <img
   src="https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_custom_background.png"
-  alt="自定义背景演示"
+  alt="Custom chart background"
   width="360"
 />
 
-### 自定义覆盖层
+### Custom Overlay
 
 <img
   src="https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_custom_overlay_ui.png"
-  alt="自定义覆盖层演示"
+  alt="Custom overlay UI"
   width="360"
 />
 
-### 自定义详情面板
+### Custom Detail Panel
 
 <img
   src="https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_custom_detail_ui.png"
-  alt="自定义详情面板演示"
+  alt="Custom detail panel"
   width="360"
 />
 
-### 自定义主图绘制
+### Custom Main Chart Drawing
 
 <img
   src="https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_custom_main_draw.png"
-  alt="自定义主图绘制演示"
+  alt="Custom main chart drawing"
   width="360"
 />
 
-### 实时数据插入
+### Realtime Data Append
 
-[查看实时数据插入视频](https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_custom_real_time_data_insert_append_end.webm)
+[Watch the realtime append demo](https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_custom_real_time_data_insert_append_end.webm)
 
-## 为什么选择它
+## Why Use It
 
-- **几分钟完成接入**：业务页面只需要准备 `List<T>` 和 `KLineDataAdapter<T>`，默认 UI 已包含蜡烛图、指标、副图、长按详情和基础状态展示，不需要为了图表改造已有数据模型。
-- **扩展点清晰可控**：通过 `KLineChartDelegate<T>` / `DeepChartDelegate<T>` 暴露绘制流程。想改背景、网格、指标文案、主图绘制、选中浮层或深度图，只替换对应模块即可。
-- **指标定义可扩展**：通过 `KLineIndicatorSpec<T>` / `KLineIndicatorSeries<T>` 定义主图和副图指标，不需要改 enum 或 switch；普通折线指标自动绘制，特殊指标可传入 renderer 自定义绘制。
-- **默认能力可复用**：自定义 delegate 可以继承 `KLineDefaultDelegateImpl<T>` 并调用 `super` 保留默认蜡烛、指标、网格、覆盖层和选中详情，只在对应方法里追加业务真正关心的那一层 UI。
-- **为高频行情优化**：K 线、指标和副图使用 `CustomPainter` 直接绘制，减少大量蜡烛和指标点带来的 Widget rebuild 压力；固定网格层和横向滚动内容层拆开绘制，网格、坐标轴和覆盖层不会跟着内容重复滚动。
-- **滑动更贴近原生手感**：横向内容层基于 `SingleChildScrollView`、`ScrollController` 和 Flutter 滚动物理实现，手指松开后的惯性滚动由框架接管；业务分页回调只响应用户主动拖动，避免 `jumpTo` / `animateTo` 这类程序化滚动重复触发加载逻辑。
-- **按 120fps 交互目标设计**：滚动、缩放、长按等高频交互会提前计算可见区节点和绘制坐标，减少 paint 阶段重复计算；默认实现交互顺滑、响应稳定，适合承载行情页里连续滑动、缩放和长按查看这类高频操作。
-- **业务模型零侵入**：K 线和深度图都通过 adapter 读取字段，后端模型、缓存模型、计算后的指标模型都可以直接接入。
-- **架构长期可维护**：核心图表、默认实现、主题布局、controller、example 数据层边界清晰，后续新增指标、替换 UI、接入不同交易所数据时不会牵一发动全身。
-- **金融图表能力完整**：内置 MA、EMA、BOLL、MACD、KDJ、RSI、WR、VOL 等常见指标，支持外部控制缩放、滚动、选中状态，也提供盘口累计深度图 `DeepChart`。
+- **Fast setup**: pass a `List<T>` and a `KLineDataAdapter<T>` to render a
+  ready-to-use Flutter candlestick chart with indicators, sub charts,
+  long-press details, and loading states.
+- **Clear extension points**: customize background, grid, indicator labels,
+  main chart drawing, selected overlays, or depth charts through
+  `KLineChartDelegate<T>` and `DeepChartDelegate<T>`.
+- **Extensible technical indicators**: define main-chart and sub-chart
+  indicators with `KLineIndicatorSpec<T>` and `KLineIndicatorSeries<T>` instead
+  of editing enums or switch statements.
+- **Reusable defaults**: extend `KLineDefaultDelegateImpl<T>` and call `super`
+  to keep the default candles, indicators, grids, overlays, and selected
+  details while adding only your business-specific drawing.
+- **Optimized for market data**: candlesticks, indicators, and sub charts are
+  painted with `CustomPainter`, reducing widget rebuild pressure for large OHLCV
+  datasets.
+- **Native-feeling gestures**: horizontal scrolling uses Flutter scroll physics
+  and only calls pagination callbacks for user-driven drag gestures.
+- **Adapter-first data model**: backend models, cached models, and calculated
+  indicator models can be used directly through adapters.
+- **Complete chart features**: built-in MA, EMA, BOLL, MACD, KDJ, RSI, WR, VOL,
+  zoom, scroll, selected state control, and cumulative order-book depth charts.
 
-## 快速开始
+## Quick Start
 
-在你的 Flutter 项目中添加依赖：
+Add the package to your Flutter project:
 
 ```bash
 flutter pub add kline_flutter
 ```
 
-或者手动写入 `pubspec.yaml`：
+Or add it manually:
 
 ```yaml
 dependencies:
-  kline_flutter: ^0.3.0
+  kline_flutter: ^0.4.0
 ```
 
-然后在业务代码中导入：
+Then import it:
 
 ```dart
 import 'package:kline_flutter/kline_flutter.dart';
 ```
 
-如果想运行本仓库的示例工程：
+To run the example app:
 
 ```bash
 git clone https://github.com/911hzh/ZHKLineFlutter.git
@@ -116,12 +133,14 @@ flutter pub get
 flutter run -d macos
 ```
 
-## 最小接入
+## Minimal Integration
 
-接入时通常只需要准备两部分：
+You usually only need two pieces:
 
-- `MyCandle`：你的业务 K 线数据类，可以来自接口、数据库或本地计算结果。
-- `MyCandleAdapter`：把业务数据转换成图表 UI 能识别的 open、high、low、close、volume 和时间文案。
+- `MyCandle`: your business candlestick model from an API, database, or local
+  calculation.
+- `MyCandleAdapter`: an adapter that exposes open, high, low, close, volume,
+  and time labels to the chart.
 
 ```dart
 import 'package:kline_flutter/kline_flutter.dart';
@@ -167,7 +186,7 @@ class MyCandleAdapter extends KLineDataAdapter<MyCandle> {
 }
 ```
 
-UI 层在你的某个页面里，直接把数据数组和 adapter 传给 `KLineWidget` 即可：
+In your UI, pass the data and adapter to `KLineWidget`:
 
 ```dart
 class MarketPage extends StatelessWidget {
@@ -184,30 +203,35 @@ class MarketPage extends StatelessWidget {
 }
 ```
 
-## 更多用法
+## More Usage
 
-README 只保留最小接入。动态指标、实时数据、外部控制、自定义绘制、自定义 UI、
-Loading / Empty / Error 和深度图接入，请查看 [`example/use_docs.md`](example/use_docs.md)。
+This README keeps the setup short. For dynamic indicators, realtime data,
+external controls, custom drawing, custom UI, Loading / Empty / Error states,
+and depth chart integration, see [`example/use_docs.md`](example/use_docs.md).
 
-## 核心能力
+## Core APIs
 
-### K 线图
+### K-line Chart
 
-- `KLineWidget<T>`：默认 K 线 UI，适合快速接入。
-- `KLineChart<T>`：核心图表组件，适合完全自定义绘制。
-- `KLineChartDelegate<T>`：绘制协议，可控制布局节点、网格、主图、副图、覆盖层和选中 UI。
-- `KLineDataAdapter<T>`：业务模型适配器。
-- `KLineController`：缩放、滚动、选中、可见区和指标状态控制。
-- `KLineIndicatorSpec<T>`：动态指标定义，可用于主图、副图和自定义 renderer。
+- `KLineWidget<T>`: default K-line UI for fast integration.
+- `KLineChart<T>`: core chart component for fully custom drawing.
+- `KLineChartDelegate<T>`: rendering protocol for layout nodes, grids, main
+  charts, sub charts, overlays, and selected-state UI.
+- `KLineDataAdapter<T>`: business model adapter.
+- `KLineController`: zoom, scroll, selected item, visible range, and indicator
+  state control.
+- `KLineIndicatorSpec<T>`: dynamic indicator definition for main charts, sub
+  charts, and custom renderers.
 
-### 深度图
+### Depth Chart
 
-- `DeepChart<T>`：默认深度图组件。
-- `DeepChartDataAdapter<T>`：盘口数据适配器。
-- `DeepChartDelegate<T>`：深度图绘制协议。
-- `DeepChartLayoutConfig`：中间图形区域和底部价格行的布局配置。
+- `DeepChart<T>`: default depth chart component.
+- `DeepChartDataAdapter<T>`: order-book data adapter.
+- `DeepChartDelegate<T>`: depth chart rendering protocol.
+- `DeepChartLayoutConfig`: layout config for the chart area and bottom price
+  row.
 
-## 简洁项目结构
+## Project Structure
 
 ```text
 lib/
@@ -225,29 +249,30 @@ example/
     └── custom_page/
 ```
 
-## 架构一览
+## Architecture
 
-架构图单独放在文档页，方便通过网页方式查看：
+The architecture diagram lives in a separate document for easier viewing:
 
-[查看完整架构图](doc/architecture.md)
+[View the architecture document](doc/architecture.md)
 
-## 适合场景
+## Use Cases
 
-- 交易所行情页、合约行情页、股票/基金行情页。
-- 需要快速接入默认 K 线 UI 的业务。
-- 需要深度定制金融图表绘制协议的业务。
-- 需要统一维护 K 线、技术指标、盘口深度和图表交互的 Flutter 项目。
+- Exchange, futures, stock, fund, and crypto market pages.
+- Flutter apps that need a default candlestick chart or K-line chart UI quickly.
+- Financial chart screens that need custom rendering protocols.
+- Apps that maintain K-line charts, technical indicators, order-book depth, and
+  trading chart interactions in one package.
 
-## 参与维护
+## Contributing
 
-这个库还在持续完善中，欢迎大家一起参与维护：
+This package is still evolving. Contributions are welcome:
 
-- 提交 Issue 反馈 Bug、性能问题或 API 设计建议。
-- 提交 Pull Request 补充图表能力、example、测试和文档。
-- 分享真实业务中的自定义 delegate、主题和交互方案。
+- Open issues for bugs, performance problems, or API design suggestions.
+- Send pull requests for chart features, examples, tests, or documentation.
+- Share real-world delegate, theme, and interaction examples.
 
-如果这个项目对你有帮助，欢迎点一个 Star，也欢迎一起把它维护成更好用的 Flutter 金融图表库。
+If this project helps you, a GitHub star and a pub.dev like are appreciated.
 
 ## License
 
-本项目采用 MIT License，详情见 [LICENSE](LICENSE)。
+This project is licensed under the MIT License. See [LICENSE](LICENSE).

--- a/README_CHINESE.md
+++ b/README_CHINESE.md
@@ -1,0 +1,253 @@
+# ZHKLine Flutter
+
+[![Flutter](https://img.shields.io/badge/Flutter-3.7.0+-blue.svg)](https://flutter.dev/)
+[![Dart](https://img.shields.io/badge/Dart-3.7.0+-blue.svg)](https://dart.dev/)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+
+一个面向金融行情场景的 Flutter 图表库，提供 K 线图、技术指标、交互控制和深度图能力。它以 `CustomPainter` 和 delegate 架构为核心，让你既可以快速接入一套默认 UI，也可以在真实业务中按需替换绘制、布局、覆盖层和数据适配。
+
+详细使用方式、自定义 UI、深度图接入和 example 说明请参考 [`example/use_docs.md`](example/use_docs.md)。
+
+## 效果预览
+
+### 动态指标与指标文案
+
+<img
+  src="https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_custom_indicator_text.png"
+  alt="动态指标与指标文案演示"
+  width="360"
+/>
+
+[查看动态指标绘制视频](https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_dynamic_indicator_draw.webm)
+
+### 滚动与缩放
+
+<img
+  src="https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_scrolling.gif"
+  alt="滚动与缩放演示"
+  width="360"
+/>
+
+### 长按详情
+
+<img
+  src="https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_tap_longpress_dataDetail.gif"
+  alt="长按十字线演示"
+  width="360"
+/>
+
+### 自定义背景
+
+<img
+  src="https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_custom_background.png"
+  alt="自定义背景演示"
+  width="360"
+/>
+
+### 自定义覆盖层
+
+<img
+  src="https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_custom_overlay_ui.png"
+  alt="自定义覆盖层演示"
+  width="360"
+/>
+
+### 自定义详情面板
+
+<img
+  src="https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_custom_detail_ui.png"
+  alt="自定义详情面板演示"
+  width="360"
+/>
+
+### 自定义主图绘制
+
+<img
+  src="https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_custom_main_draw.png"
+  alt="自定义主图绘制演示"
+  width="360"
+/>
+
+### 实时数据插入
+
+[查看实时数据插入视频](https://raw.githubusercontent.com/911hzh/ZHKLineFlutter/develop-0.3.0/lib/assets/show/flutter_custom_real_time_data_insert_append_end.webm)
+
+## 为什么选择它
+
+- **几分钟完成接入**：业务页面只需要准备 `List<T>` 和 `KLineDataAdapter<T>`，默认 UI 已包含蜡烛图、指标、副图、长按详情和基础状态展示，不需要为了图表改造已有数据模型。
+- **扩展点清晰可控**：通过 `KLineChartDelegate<T>` / `DeepChartDelegate<T>` 暴露绘制流程。想改背景、网格、指标文案、主图绘制、选中浮层或深度图，只替换对应模块即可。
+- **指标定义可扩展**：通过 `KLineIndicatorSpec<T>` / `KLineIndicatorSeries<T>` 定义主图和副图指标，不需要改 enum 或 switch；普通折线指标自动绘制，特殊指标可传入 renderer 自定义绘制。
+- **默认能力可复用**：自定义 delegate 可以继承 `KLineDefaultDelegateImpl<T>` 并调用 `super` 保留默认蜡烛、指标、网格、覆盖层和选中详情，只在对应方法里追加业务真正关心的那一层 UI。
+- **为高频行情优化**：K 线、指标和副图使用 `CustomPainter` 直接绘制，减少大量蜡烛和指标点带来的 Widget rebuild 压力；固定网格层和横向滚动内容层拆开绘制，网格、坐标轴和覆盖层不会跟着内容重复滚动。
+- **滑动更贴近原生手感**：横向内容层基于 `SingleChildScrollView`、`ScrollController` 和 Flutter 滚动物理实现，手指松开后的惯性滚动由框架接管；业务分页回调只响应用户主动拖动，避免 `jumpTo` / `animateTo` 这类程序化滚动重复触发加载逻辑。
+- **按 120fps 交互目标设计**：滚动、缩放、长按等高频交互会提前计算可见区节点和绘制坐标，减少 paint 阶段重复计算；默认实现交互顺滑、响应稳定，适合承载行情页里连续滑动、缩放和长按查看这类高频操作。
+- **业务模型零侵入**：K 线和深度图都通过 adapter 读取字段，后端模型、缓存模型、计算后的指标模型都可以直接接入。
+- **架构长期可维护**：核心图表、默认实现、主题布局、controller、example 数据层边界清晰，后续新增指标、替换 UI、接入不同交易所数据时不会牵一发动全身。
+- **金融图表能力完整**：内置 MA、EMA、BOLL、MACD、KDJ、RSI、WR、VOL 等常见指标，支持外部控制缩放、滚动、选中状态，也提供盘口累计深度图 `DeepChart`。
+
+## 快速开始
+
+在你的 Flutter 项目中添加依赖：
+
+```bash
+flutter pub add kline_flutter
+```
+
+或者手动写入 `pubspec.yaml`：
+
+```yaml
+dependencies:
+  kline_flutter: ^0.3.0
+```
+
+然后在业务代码中导入：
+
+```dart
+import 'package:kline_flutter/kline_flutter.dart';
+```
+
+如果想运行本仓库的示例工程：
+
+```bash
+git clone https://github.com/911hzh/ZHKLineFlutter.git
+cd ZHKLineFlutter
+cd example
+flutter pub get
+flutter run -d macos
+```
+
+## 最小接入
+
+接入时通常只需要准备两部分：
+
+- `MyCandle`：你的业务 K 线数据类，可以来自接口、数据库或本地计算结果。
+- `MyCandleAdapter`：把业务数据转换成图表 UI 能识别的 open、high、low、close、volume 和时间文案。
+
+```dart
+import 'package:kline_flutter/kline_flutter.dart';
+
+class MyCandle {
+  const MyCandle({
+    required this.open,
+    required this.high,
+    required this.low,
+    required this.close,
+    required this.volume,
+    required this.timeLabel,
+  });
+
+  final double open;
+  final double high;
+  final double low;
+  final double close;
+  final double volume;
+  final String timeLabel;
+}
+
+class MyCandleAdapter extends KLineDataAdapter<MyCandle> {
+  const MyCandleAdapter();
+
+  @override
+  double open(MyCandle item) => item.open;
+
+  @override
+  double high(MyCandle item) => item.high;
+
+  @override
+  double low(MyCandle item) => item.low;
+
+  @override
+  double close(MyCandle item) => item.close;
+
+  @override
+  double volume(MyCandle item) => item.volume;
+
+  @override
+  String dateLabel(MyCandle item) => item.timeLabel;
+}
+```
+
+UI 层在你的某个页面里，直接把数据数组和 adapter 传给 `KLineWidget` 即可：
+
+```dart
+class MarketPage extends StatelessWidget {
+  const MarketPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return KLineWidget<MyCandle>(
+      dataSource: candles,
+      adapter: const MyCandleAdapter(),
+      initialIndicators: const [KLineDefaultIndicators.volumeId],
+    );
+  }
+}
+```
+
+## 更多用法
+
+README 只保留最小接入。动态指标、实时数据、外部控制、自定义绘制、自定义 UI、
+Loading / Empty / Error 和深度图接入，请查看 [`example/use_docs.md`](example/use_docs.md)。
+
+## 核心能力
+
+### K 线图
+
+- `KLineWidget<T>`：默认 K 线 UI，适合快速接入。
+- `KLineChart<T>`：核心图表组件，适合完全自定义绘制。
+- `KLineChartDelegate<T>`：绘制协议，可控制布局节点、网格、主图、副图、覆盖层和选中 UI。
+- `KLineDataAdapter<T>`：业务模型适配器。
+- `KLineController`：缩放、滚动、选中、可见区和指标状态控制。
+- `KLineIndicatorSpec<T>`：动态指标定义，可用于主图、副图和自定义 renderer。
+
+### 深度图
+
+- `DeepChart<T>`：默认深度图组件。
+- `DeepChartDataAdapter<T>`：盘口数据适配器。
+- `DeepChartDelegate<T>`：深度图绘制协议。
+- `DeepChartLayoutConfig`：中间图形区域和底部价格行的布局配置。
+
+## 简洁项目结构
+
+```text
+lib/
+├── kline_flutter.dart
+└── src/
+    ├── kline/
+    └── deepchart/
+
+example/
+├── lib/base/api/
+├── lib/base/store/
+└── lib/module/usecase/pages/
+    ├── kline/
+    ├── deep_chart/
+    └── custom_page/
+```
+
+## 架构一览
+
+架构图单独放在文档页，方便通过网页方式查看：
+
+[查看完整架构图](doc/architecture.md)
+
+## 适合场景
+
+- 交易所行情页、合约行情页、股票/基金行情页。
+- 需要快速接入默认 K 线 UI 的业务。
+- 需要深度定制金融图表绘制协议的业务。
+- 需要统一维护 K 线、技术指标、盘口深度和图表交互的 Flutter 项目。
+
+## 参与维护
+
+这个库还在持续完善中，欢迎大家一起参与维护：
+
+- 提交 Issue 反馈 Bug、性能问题或 API 设计建议。
+- 提交 Pull Request 补充图表能力、example、测试和文档。
+- 分享真实业务中的自定义 delegate、主题和交互方案。
+
+如果这个项目对你有帮助，欢迎点一个 Star，也欢迎一起把它维护成更好用的 Flutter 金融图表库。
+
+## License
+
+本项目采用 MIT License，详情见 [LICENSE](LICENSE)。

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: kline_flutter
-description: "一个面向金融行情场景的 Flutter 图表库，提供 K 线图、技术指标、交互控制和深度图能力。它以 `CustomPainter` 和 delegate 架构为核心，让你既可以快速接入一套默认 UI，也可以在真实业务中按需替换绘制、布局、覆盖层和数据适配。"
+description: "A Flutter candlestick and K-line financial chart library with technical indicators, OHLCV trading charts, depth charts, and customizable delegates."
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -13,7 +13,7 @@ description: "一个面向金融行情场景的 Flutter 图表库，提供 K 线
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.3.1
+version: 0.4.0
 repository: https://github.com/911hzh/ZHKLineFlutter
 environment:
   sdk: ^3.7.0


### PR DESCRIPTION
## Summary

- Switch the default README to English for pub.dev and GitHub discovery.
- Move the original Chinese README to `README_CHINESE.md`.
- Update package metadata and changelog for `0.4.0`.

## Why

The package is preparing a `0.4.0` release focused on improving pub.dev search visibility and trust signals before adding more product features.

## Validation

- `rg -n "\p{Han}" pubspec.yaml README.md CHANGELOG.md`
- `rg -n "\p{Han}" README_CHINESE.md`
- `git diff --check`
- `flutter pub publish --dry-run` -> `Package has 0 warnings.`

## Notes

- No chart implementation code changed.
- Publisher verification, GitHub topics, and external article publishing are intentionally left as follow-up operational work.